### PR TITLE
Fix docker in rails 6 1

### DIFF
--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -122,7 +122,7 @@ module ActiveElasticJob
       end
 
       def app_runs_in_docker_container?
-        `[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /(ecs|docker)/
+        (`[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /(ecs|docker)/).present?
       end
     end
   end

--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -47,7 +47,7 @@ module ActiveElasticJob
             rescue ActiveElasticJob::MessageVerifier::InvalidDigest => e
               return FORBIDDEN_RESPONSE
             end
-            return OK_RESPONSE 
+            return OK_RESPONSE
           end
         end
         @app.call(env)
@@ -122,7 +122,7 @@ module ActiveElasticJob
       end
 
       def app_runs_in_docker_container?
-        @app_in_docker_container ||= `[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /(ecs|docker)/
+        `[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /(ecs|docker)/
       end
     end
   end

--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -118,7 +118,11 @@ module ActiveElasticJob
       end
 
       def sent_from_docker_host?(request)
-        app_runs_in_docker_container? && request.remote_ip =~ DOCKER_HOST_IP
+        app_runs_in_docker_container? && ip_originates_from_docker?(request)
+      end
+
+      def ip_originates_from_docker?(request)
+        (request.remote_ip =~ DOCKER_HOST_IP).present? or (request.remote_addr =~ DOCKER_HOST_IP).present?
       end
 
       def app_runs_in_docker_container?

--- a/spec/active_elastic_job/rack/sqs_message_consumer_spec.rb
+++ b/spec/active_elastic_job/rack/sqs_message_consumer_spec.rb
@@ -142,6 +142,19 @@ describe ActiveElasticJob::Rack::SqsMessageConsumer do
         end
       end
 
+      context 'in a rails environment where x-forwarded-for counts' do
+        before do
+          env['REMOTE_ADDR'] = '172.17.0.1'
+          env['HTTP_X_FORWARDED_FOR'] = ' 127.0.0.1'
+        end
+
+        it "intercepts request and performs the job" do
+          expect(app).not_to receive(:call).with(env)
+
+          expect(sqs_message_consumer.call(env)[0]).to eq('200')
+        end
+      end
+
       context 'in a multi-container environment' do
         before do
           env['REMOTE_ADDR'] = '172.17.0.2'


### PR DESCRIPTION
### WHY

When testing this on Rails 6.1 all jobs from sqsd failed with a 403 response.

After some further digging I found that the rack request variables now looked like
  request.remote_ip= 127.0.0.1 and 
  request.remote_addr=172.17.0.1 

which seems to be a change in Rails to honour the x-forwarded-for header.

Closes #124 