### PR TITLE
Add support for FIFO queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Subsequently it triggers its execution by calling the `#perform_now` method.
      schedule: "0 23 * * *"
   ```
 
+## FIFO Queues
+
+FIFO (First-In-First-Out) queues are designed to enhance messaging between applications when the order of operations and
+events is critical, or where duplicates can't be tolerated. FIFO queues also provide exactly-once processing but have a
+limited number of transactions per second (TPS).
+
+In order to make it work, you'll need to specify both `message_deduplication_id` and `message_group_id` in your job's
+arguments when calling `perform_later` or `perform_now`. Both mentioned arguments are required and both are `String` objects.
+
 ## Optional configuration
 This gem is configurable in case your setup requires different settings than the defaults.
 The snippet below shows the various configurable settings and their defaults.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ FIFO (First-In-First-Out) queues are designed to enhance messaging between appli
 events is critical, or where duplicates can't be tolerated. FIFO queues also provide exactly-once processing but have a
 limited number of transactions per second (TPS).
 
-In order to make it work, you'll need to specify both `message_deduplication_id` and `message_group_id` in your job's
-arguments when calling `perform_later` or `perform_now`. Both mentioned arguments are required and both are `String` objects.
+The message group id will be set to the job type, and the message deduplication id will be set to the job id.
 
 ## Optional configuration
 This gem is configurable in case your setup requires different settings than the defaults.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You have your Rails application deployed on the [Amazon Elastic Beanstalk](http:
 2. Create an SQS queue:
   * Log into your Amazon Web Service Console and select _SQS_ from the services menu.
   * Create a new queue. Select a name of choice but do not forget to use the **same name** in your Active Job class definition.
-  * Make sure you select a Standard Queue. **FIFO Queue will not work out of the box**.
 
     ```Ruby
     class YourJob < ActiveJob::Base

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ limited number of transactions per second (TPS).
 
 The message group id will be set to the job type, and the message deduplication id will be set to the job id.
 
+Note: Periodic tasks don't work for worker environments that are configured with Amazon SQS FIFO queues.
+
 ## Optional configuration
 This gem is configurable in case your setup requires different settings than the defaults.
 The snippet below shows the various configurable settings and their defaults.

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -135,11 +135,12 @@ module ActiveJob
             message_body: serialized_job,
             delay_seconds: calculate_delay(timestamp),
             message_attributes: build_message_attributes(serialized_job)
-          }.merge(fifo_required_params(serialized_job))
+          }
 
           if queue_name.split('.').last == 'fifo'
             args.merge(fifo_required_params(serialized_job))
           end
+          return args
         end
 
         def build_message_attributes(serialized_job)

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -160,23 +160,10 @@ module ActiveJob
         def fifo_required_params(serialized_job)
           parsed_job = JSON.parse(serialized_job)
 
-          fifo_required_keys.each_with_object({}) do |key, hsh|
-            value = parsed_job['arguments'].select { |arg| arg.is_a?(Hash) && arg.has_key?(key) }.first
-            hsh[key] = value.present? ? value : default_value(key, parsed_job)
-          end
-        end
-
-        def default_value(key, parsed_job)
-          case key
-          when :message_group_id
-            parsed_job['job_class']
-          when :message_deduplication_id
-            parsed_job['job_id']
-          end
-        end
-
-        def fifo_required_keys
-          %i[message_group_id message_deduplication_id]
+          {
+            message_group_id: parsed_job['job_class'],
+            message_deduplication_id: parsed_job['job_id']
+          }
         end
 
         def queue_url(queue_name)

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -138,8 +138,9 @@ module ActiveJob
           }
 
           if queue_name.split('.').last == 'fifo'
-            args.merge(fifo_required_params(serialized_job))
+            args.merge!(fifo_required_params(serialized_job))
           end
+
           return args
         end
 

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -130,21 +130,50 @@ module ActiveJob
         end
 
         def build_message(queue_name, serialized_job, timestamp)
-          {
+          args = {
             queue_url: queue_url(queue_name),
             message_body: serialized_job,
             delay_seconds: calculate_delay(timestamp),
-            message_attributes: {
-              "message-digest".freeze => {
-                string_value: message_digest(serialized_job),
-                data_type: "String".freeze
-              },
-              origin: {
-                string_value: ActiveElasticJob::ACRONYM,
-                data_type: "String".freeze
-              }
+            message_attributes: build_message_attributes(serialized_job)
+          }.merge(fifo_required_params(serialized_job))
+
+          if queue_name.split('.').last == 'fifo'
+            args.merge(fifo_required_params(serialized_job))
+          end
+        end
+
+        def build_message_attributes(serialized_job)
+          {
+            "message-digest".freeze => {
+              string_value: message_digest(serialized_job),
+              data_type: "String".freeze
+            },
+            origin: {
+              string_value: ActiveElasticJob::ACRONYM,
+              data_type: "String".freeze
             }
           }
+        end
+
+        def fifo_required_params(serialized_job)
+          fifo_required_keys.each_with_object({}) do |key, hsh|
+            parsed_job = JSON.parse(serialized_job)
+            value = parsed_job['arguments'].select { |arg| arg.is_a?(Hash) && arg.has_key?(key) }.first
+            hsh[key] = value.present? ? value : default_value(key, parsed_job)
+          end
+        end
+
+        def default_value(key, parsed_job)
+          case key
+          when :message_group_id
+            parsed_job['job_class']
+          when :message_deduplication_id
+            parsed_job['job_id']
+          end
+        end
+
+        def fifo_required_keys
+          %i[message_group_id message_deduplication_id]
         end
 
         def queue_url(queue_name)
@@ -198,13 +227,13 @@ module ActiveJob
           Rails.application.config.active_elastic_job
         end
 
-        def message_digest(messsage_body)
+        def message_digest(message_body)
           @verifier ||= ActiveElasticJob::MessageVerifier.new(secret_key_base)
-          @verifier.generate_digest(messsage_body)
+          @verifier.generate_digest(message_body)
         end
 
-        def verify_md5_digests!(response, messsage_body, message_attributes)
-          calculated = md5_of_message_body(messsage_body)
+        def verify_md5_digests!(response, message_body, message_attributes)
+          calculated = md5_of_message_body(message_body)
           returned = response.md5_of_message_body
           if calculated != returned
             raise MD5MismatchError.new response.message_id, calculated, returned
@@ -213,7 +242,7 @@ module ActiveJob
           if message_attributes
             calculated = md5_of_message_attributes(message_attributes)
             returned = response.md5_of_message_attributes
-            if  calculated != returned
+            if calculated != returned
               raise MD5MismatchError.new response.message_id, calculated, returned
             end
           end

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -158,8 +158,9 @@ module ActiveJob
         end
 
         def fifo_required_params(serialized_job)
+          parsed_job = JSON.parse(serialized_job)
+
           fifo_required_keys.each_with_object({}) do |key, hsh|
-            parsed_job = JSON.parse(serialized_job)
             value = parsed_job['arguments'].select { |arg| arg.is_a?(Hash) && arg.has_key?(key) }.first
             hsh[key] = value.present? ? value : default_value(key, parsed_job)
           end


### PR DESCRIPTION
This is a resubmission of #78, with the additional work done by @Chacattack (see https://github.com/active-elastic-job/active-elastic-job/pull/78#issuecomment-460497393) to get the tests to pass.

The original implementation has been reduced in scope (the group and deduplication ids are now only set automatically, not explicitly), some bugs were fixed, and a spec added.