### PR TITLE
Fix docs for Extended Nginx read timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ However, one of the best parts about `active-elastic-job` is that you can use th
 
 #### Amazon Linux 2
 
+Create two files (for application / configuration deployment) with same content.
+
 `.platform/hooks/predeploy/nginx_read_timeout.sh`
+`.platform/confighooks/predeploy/nginx_read_timeout.sh`
 ```
 #!/usr/bin/env bash
 set -xe


### PR DESCRIPTION
Call the hook on the time of application and configuration deployment.
Small fix on README.