### PR TITLE
Allow scopes to set message_group_id.

### DIFF
--- a/active-elastic-job.gemspec
+++ b/active-elastic-job.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk-sqs', '~> 1'
   spec.add_dependency 'rails', '>= 5.2.6', '< 7.1'
+  spec.add_dependency 'concurrent-ruby', '~> 1.2'
 
   spec.add_development_dependency 'amazing_print', '~> 1.2'
   spec.add_development_dependency 'benchmark-ips', '~> 2.8'

--- a/lib/active_elastic_job.rb
+++ b/lib/active_elastic_job.rb
@@ -4,6 +4,7 @@ require 'active_elastic_job/md5_message_digest_calculation'
 require 'active_job/queue_adapters/active_elastic_job_adapter'
 require 'active_elastic_job/rack/sqs_message_consumer'
 require 'active_elastic_job/message_verifier'
+require 'active_elastic_job/message_group_scope'
 
 module ActiveElasticJob
   ACRONYM = 'AEJ'.freeze

--- a/lib/active_elastic_job/message_group_scope.rb
+++ b/lib/active_elastic_job/message_group_scope.rb
@@ -1,0 +1,15 @@
+module ActiveElasticJob
+  class MessageGroupScope
+    @@message_group_suffix = Concurrent::ThreadLocalVar.new { nil }
+
+    def self.message_group_suffix
+      @@message_group_suffix.value
+    end
+
+    def scope(message_group_suffix, &block)
+      @subscribers.value = message_group_suffix
+      block.call
+      @subscribers.value = nil
+    end
+  end
+end

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -159,9 +159,14 @@ module ActiveJob
 
         def fifo_required_params(serialized_job)
           parsed_job = JSON.parse(serialized_job)
+          message_group_id = if ActiveElasticJob::MessageGroupScope.message_group_suffix.nil?
+            parsed_job['job_class']
+          else
+            "#{parsed_job['job_class']}-#{ActiveElasticJob::MessageGroupScope.message_group_suffix}"
+          end
 
           {
-            message_group_id: parsed_job['job_class'],
+            message_group_id: message_group_id,
             message_deduplication_id: parsed_job['job_id']
           }
         end


### PR DESCRIPTION
The idea is be able to modify message_group id.

Usage:

```ruby
ActiveElasticJob::MessageGroupScope.scope('MyScope') do
  MyJob.perform_later(arg)
end
```

I expect to have a `message_group_id = "Myjob-MyScope"` instead of the default one `MyJob`.