### PR TITLE
Add Rails7.x support

### DIFF
--- a/active-elastic-job.gemspec
+++ b/active-elastic-job.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'aws-sdk-sqs', '~> 1'
-  spec.add_dependency 'rails', '>= 5.2.6', '< 7.1'
+  spec.add_dependency 'rails', '>= 5.2.6', '< 8'
 
   spec.add_development_dependency 'amazing_print', '~> 1.2'
   spec.add_development_dependency 'benchmark-ips', '~> 2.8'


### PR DESCRIPTION
Rails 7.1 has been released, so I've expanded the supported versions. 
From my checks, it seems to be running smoothly on Elastic Beanstalk.