### PR TITLE
Add alternative docker check - fixes AL2023 issue

### DIFF
--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -141,7 +141,7 @@ module ActiveElasticJob
       end
 
       def app_runs_in_docker_container?
-        (`[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /(ecs|docker)/).present?
+        File.exist?('/.dockerenv') || (`[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /(ecs|docker)/).present?
       end
     end
   end


### PR DESCRIPTION
This fixes #153 and gets things working on AL2023. At least for me using the Docker platform branch.

I'm not familiar enough with Docker, containers, etc. to understand why, but the existing check for Docker was coming back as false. The reason is that the current check (`cat cat /proc/1/cgroup`) is now only returning `0::/`

I did some research and it seems that checking for the existence of `/.dockerenv` is an undocumented but semi-blessed method. In any case, it works 🎉 

Didn't see any tests around this, but I can confirm I now have this working in production.